### PR TITLE
feat(table): support Hinode's wrap argument on data tables

### DIFF
--- a/assets/js/modules/simple-datatables/simple-datatables.load.js
+++ b/assets/js/modules/simple-datatables/simple-datatables.load.js
@@ -44,7 +44,19 @@ const wrapLastColumn = (table) => {
         return table
     }
 
-    headerRow.childNodes = headerRow.childNodes.slice(0, -1)
+    // Hides the heading of the wrapped column, rather than removing it. The library measures column
+    // widths by walking the rendered `<th>` list in lockstep with its row model, so the header must
+    // keep all of its cells. This mirrors Hinode's plain-table wrap, which hides the heading too.
+    const lastHeader = headerRow.childNodes.length - 1
+    headerRow.childNodes = headerRow.childNodes.map((th, index) => index !== lastHeader
+        ? th
+        : {
+            ...th,
+            attributes: {
+                ...th.attributes,
+                class: `${th.attributes?.class ?? ""} d-none`.trim()
+            }
+        })
 
     // Marks the table for the wrap-specific striping rules in Hinode's SCSS.
     table.attributes = {
@@ -73,6 +85,9 @@ const wrapLastColumn = (table) => {
             },
             {
                 nodeName: "TR",
+                // Carries the source row's attributes, so `data-index` survives on the synthesized
+                // row and the library's row-selection handler keeps reporting the right record.
+                attributes: { ...row.attributes },
                 childNodes: [{
                     ...last,
                     attributes: { ...last.attributes, colspan: String(span) }

--- a/assets/js/modules/simple-datatables/simple-datatables.load.js
+++ b/assets/js/modules/simple-datatables/simple-datatables.load.js
@@ -1,6 +1,89 @@
 // Adapted from https://github.com/fiduswriter/simple-datatables/blob/main/docs/demos/19-bootstrap-table/index.html
 
 
+// Applies Bootstrap's header markup to simple-datatables' virtual DOM.
+const styleHeader = (table) => {
+    const thead = table.childNodes[0]
+    thead.childNodes[0].childNodes.forEach(th => {
+        if (!th.attributes) {
+            th.attributes = {}
+        }
+        th.attributes.scope = "col"
+        const innerHeader = th.childNodes[0]
+        if (!innerHeader.attributes) {
+            innerHeader.attributes = {}
+        }
+        let innerHeaderClass = innerHeader.attributes.class ? `${innerHeader.attributes.class} th-inner` : "th-inner"
+
+        if (innerHeader.nodeName === "a") {
+            innerHeaderClass += " sortable sortable-center both"
+            if (th.attributes.class?.includes("desc")) {
+                innerHeaderClass += " desc"
+            } else if (th.attributes.class?.includes("asc")) {
+                innerHeaderClass += " asc"
+            }
+        }
+        innerHeader.attributes.class = innerHeaderClass
+    })
+    return table
+}
+
+// Mirrors Bootstrap's $grid-breakpoints. A wrapped table switches layout below the site's main
+// breakpoint, following Bootstrap's `media-breakpoint-down` convention.
+const breakpoints = { xs: 0, sm: 576, md: 768, lg: 992, xl: 1200, xxl: 1400 }
+
+// Moves the last column of every record onto a row of its own, so wide tables stay readable on
+// small devices. This rewrites the virtual DOM only - never the row model - so sorting, searching
+// and paging keep operating on the unmodified data, and the pager keeps counting records rather
+// than rendered rows.
+const wrapLastColumn = (table) => {
+    const thead = table.childNodes[0]
+    const tbody = table.childNodes[1]
+    const headerRow = thead?.childNodes[0]
+    if (!headerRow || headerRow.childNodes.length < 2 || !tbody) {
+        return table
+    }
+
+    headerRow.childNodes = headerRow.childNodes.slice(0, -1)
+
+    // Marks the table for the wrap-specific striping rules in Hinode's SCSS.
+    table.attributes = {
+        ...table.attributes,
+        class: `${table.attributes?.class ?? ""} table-wrap`.trim()
+    }
+
+    tbody.childNodes = tbody.childNodes.flatMap(row => {
+        const cells = row.childNodes
+        if (!cells || cells.length < 2) {
+            return [row]
+        }
+        const span = cells.length - 1
+        const last = cells[span]
+
+        return [
+            {
+                ...row,
+                childNodes: cells.slice(0, span).map(cell => ({
+                    ...cell,
+                    attributes: {
+                        ...cell.attributes,
+                        class: `${cell.attributes?.class ?? ""} table-border-bottom-wrap`.trim()
+                    }
+                }))
+            },
+            {
+                nodeName: "TR",
+                childNodes: [{
+                    ...last,
+                    attributes: { ...last.attributes, colspan: String(span) }
+                }]
+            }
+        ]
+    })
+
+    return table
+}
+
 let tableOptions = {
     locale: "{{ site.Language.Lang | default "en" }}",
     labels: {
@@ -20,50 +103,15 @@ let tableOptions = {
         paginationListItemLink: "page-link",
         input: "form-control search-input",
         search: "float-right search-data-table btn-group"
-    },
-    tableRender: (_data, table, _type) => {
-        // ignore type ('main', 'print', 'header', 'message')
-        const thead = table.childNodes[0]
-        thead.childNodes[0].childNodes.forEach(th => {
-            if (!th.attributes) {
-                th.attributes = {}
-            }
-            th.attributes.scope = "col"
-            const innerHeader = th.childNodes[0]
-            if (!innerHeader.attributes) {
-                innerHeader.attributes = {}
-            }
-            let innerHeaderClass = innerHeader.attributes.class ? `${innerHeader.attributes.class} th-inner` : "th-inner"
-    
-            if (innerHeader.nodeName === "a") {
-                innerHeaderClass += " sortable sortable-center both"
-                if (th.attributes.class?.includes("desc")) {
-                    innerHeaderClass += " desc"
-                } else if (th.attributes.class?.includes("asc")) {
-                    innerHeaderClass += " asc"
-                }
-            }
-            innerHeader.attributes.class = innerHeaderClass
-        })    
-        return table
     }
-}    
+}
 
 
-// Track DataTable instances keyed by filter container ID.
-// An array is used per ID because both the regular and responsive-wrapped
-// table variants need to be filtered together.
+// Track DataTable instances keyed by filter container ID. An array is used per ID so several
+// tables can share one filter button group.
 const tableFilterInstances = {}
 
 document.querySelectorAll('.data-table').forEach(tbl => {
-    let sortable = (tbl.getAttribute('data-table-sortable') === 'true')
-    tableOptions.sortable = sortable
-    let paging = (tbl.getAttribute('data-table-paging') === 'true')
-    tableOptions.paging = paging
-    let searchable = (tbl.getAttribute('data-table-searchable') === 'true')
-    tableOptions.searchable = searchable
-    let perPage = parseInt(tbl.getAttribute('data-table-paging-option-perPage')) || 10
-    tableOptions.perPage = perPage
     let perPageSelectAttr = tbl.getAttribute('data-table-paging-option-perPageSelect');
     let perPageSelect;
     if (perPageSelectAttr) {
@@ -76,9 +124,43 @@ document.querySelectorAll('.data-table').forEach(tbl => {
     } else {
         perPageSelect = [5, 10, 20, 50, ["{{ T "tablePerPageSelectAll" }}", -1]];
     }
-    tableOptions.perPageSelect = perPageSelect;
 
-    const dt = new window.simpleDatatables.DataTable(tbl, tableOptions)
+    const options = {
+        ...tableOptions,
+        sortable: (tbl.getAttribute('data-table-sortable') === 'true'),
+        paging: (tbl.getAttribute('data-table-paging') === 'true'),
+        searchable: (tbl.getAttribute('data-table-searchable') === 'true'),
+        perPage: parseInt(tbl.getAttribute('data-table-paging-option-perPage')) || 10,
+        perPageSelect: perPageSelect
+    }
+
+    // A wrapped table renders its last column on a row of its own below the main breakpoint. At
+    // `xs` the max-width evaluates below zero, so the query never matches and wrapping is off -
+    // matching Hinode, which does not emit the attribute at `xs` either.
+    let media = null
+    if (tbl.getAttribute('data-table-wrap') === 'true') {
+        const name = tbl.getAttribute('data-table-wrap-breakpoint') || 'md'
+        const width = breakpoints[name] ?? breakpoints.md
+        media = window.matchMedia(`(max-width: ${width - 0.02}px)`)
+    }
+
+    options.tableRender = (_data, table, type) => {
+        const rendered = styleHeader(table)
+        // 'header' is the sticky-header clone, 'message' the no-rows placeholder and 'print' the
+        // print view - none of them wrap.
+        if (type !== 'main' || !media?.matches) {
+            return rendered
+        }
+        return wrapLastColumn(rendered)
+    }
+
+    const dt = new window.simpleDatatables.DataTable(tbl, options)
+
+    // Redraw on the other side of the breakpoint. `update(true)` keeps the active sort, page and
+    // search term; `refresh()` would clear the search.
+    if (media) {
+        media.addEventListener('change', () => dt.update(true))
+    }
 
     // Register instance for category filter integration
     const filterId = tbl.getAttribute('data-filter-id')

--- a/assets/js/modules/simple-datatables/simple-datatables.load.js
+++ b/assets/js/modules/simple-datatables/simple-datatables.load.js
@@ -30,7 +30,11 @@ const styleHeader = (table) => {
 
 // Mirrors Bootstrap's $grid-breakpoints. A wrapped table switches layout below the site's main
 // breakpoint, following Bootstrap's `media-breakpoint-down` convention.
-const breakpoints = { xs: 0, sm: 576, md: 768, lg: 992, xl: 1200, xxl: 1400 }
+//
+// Hinode concatenates every module's `.load.js` into one classic script, so all of them share a
+// single top-level scope and a duplicate `const` would be a parse-time SyntaxError that takes down
+// the whole bundle. Hence the module-specific name.
+const dataTableBreakpoints = { xs: 0, sm: 576, md: 768, lg: 992, xl: 1200, xxl: 1400 }
 
 // Moves the last column of every record onto a row of its own, so wide tables stay readable on
 // small devices. This rewrites the virtual DOM only - never the row model - so sorting, searching
@@ -155,7 +159,7 @@ document.querySelectorAll('.data-table').forEach(tbl => {
     let media = null
     if (tbl.getAttribute('data-table-wrap') === 'true') {
         const name = tbl.getAttribute('data-table-wrap-breakpoint') || 'md'
-        const width = breakpoints[name] ?? breakpoints.md
+        const width = dataTableBreakpoints[name] ?? dataTableBreakpoints.md
         media = window.matchMedia(`(max-width: ${width - 0.02}px)`)
     }
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.19
 
 require (
 	github.com/gethinode/mod-bootstrap v1.3.7 // indirect
-	github.com/gethinode/mod-utils/v6 v6.4.1 // indirect
+	github.com/gethinode/mod-utils/v6 v6.4.2 // indirect
 	github.com/twbs/bootstrap v5.3.8+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,7 @@ github.com/gethinode/mod-utils/v6 v6.4.0 h1:l49KrawKE/7c6XE00wXQ9T5/kuTfiETerBz6
 github.com/gethinode/mod-utils/v6 v6.4.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/gethinode/mod-utils/v6 v6.4.1 h1:jHiJEwSjLp6tqIXayxUQTxILwnM7hWMgYyTYhxFE3ZA=
 github.com/gethinode/mod-utils/v6 v6.4.1/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
+github.com/gethinode/mod-utils/v6 v6.4.2 h1:xh3XBpuvD+AisycxqEX0Ao90wKlu7cuKM0QOZcdVtP4=
+github.com/gethinode/mod-utils/v6 v6.4.2/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/twbs/bootstrap v5.3.8+incompatible h1:eK1fsXP7R/FWFt+sSNmmvUH9usPocf240nWVw7Dh02o=
 github.com/twbs/bootstrap v5.3.8+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
Hinode's table `wrap` argument moves a wide table's last column onto a full-width row of its own below the site's main breakpoint. Until now it was incompatible with data tables, because Hinode rendered a pre-split, ragged table that simple-datatables' uniform row model cannot represent.

Hinode now renders a wrapped data table **uniformly** and marks it with `data-table-wrap` / `data-table-wrap-breakpoint`. This PR makes the module build the wrapped layout itself, in the browser, through simple-datatables' `tableRender` hook.

## Why the hook

`tableRender` rewrites the **virtual DOM** on each render, whereas sorting, searching and paging operate on the library's internal **row model**. Transforming the virtual DOM is therefore purely cosmetic: the row model stays uniform, so the pager keeps counting records rather than rendered rows, sorting keeps each wrapped cell attached to its record, and search still matches text in the wrapped column.

Crossing the breakpoint redraws via `dt.update(true)`, which preserves the active sort, page and search term — `refresh()` would clear the search.

## Note on the second commit

The first draft *removed* the wrapped column's `<th>`. That desynchronized the rendered header count from the row model, and since `fixedColumns` defaults to `true`, `_measureWidths()` re-renders through `tableRender` and then walks the DOM headers in lockstep with `data.headings`, dereferencing `activeDOMHeadings[N-1].offsetWidth` on an `undefined` element. Every wrapped data table threw a `TypeError` — on load, on crossing the breakpoint, and on any window resize (via the library's own `_onResize`). The header cell is now kept and hidden with `d-none`, restoring the invariant and matching Hinode's plain wrap path.

## Verification

Driven in a real browser against the Hinode exampleSite: zero console errors; the pager reports 2 pages for 4 records at `perPage=2` (records, not rendered rows); sorting keeps descriptions attached to their records; searching a word present only in the wrapped column still matches; the no-results message renders cleanly; sort, page and search all survive a breakpoint crossing; and no class accumulates across repeated sorts, searches and resizes.

Requires Hinode with the corresponding `wrap` rework (gethinode/hinode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)