### PR TITLE
fix(table): drive the category filter through the row model

### DIFF
--- a/assets/js/modules/simple-datatables/simple-datatables.load.js
+++ b/assets/js/modules/simple-datatables/simple-datatables.load.js
@@ -209,7 +209,16 @@ document.querySelectorAll('[data-filter-table]').forEach(btn => {
         if (!instances) return
 
         instances.forEach(({ dt, filterCol }) => {
-            dt.search(filterValue, [filterCol], 'category-filter')
+            if (filterValue) {
+                dt.search(filterValue, [filterCol], 'category-filter')
+            } else {
+                // `search()` ignores its `source` argument on the empty-term path: it resets every
+                // query, wiping a term the visitor typed into the search box along with the
+                // category filter. `multiSearch(queries, source)` drops only the queries carrying
+                // that source and re-concats the rest, so clearing the filter with 'All' leaves a
+                // free-text search in place.
+                dt.multiSearch([], 'category-filter')
+            }
         })
     })
 })

--- a/assets/js/modules/simple-datatables/simple-datatables.load.js
+++ b/assets/js/modules/simple-datatables/simple-datatables.load.js
@@ -191,10 +191,11 @@ document.querySelectorAll('.data-table').forEach(tbl => {
 })
 
 // Category filter button group.
-// Filtering runs through simple-datatables' search(term, columns, source), so it composes with
-// sorting, pagination and the free-text search: the named source 'category-filter' is independent
-// of the search input, so both narrow the result set at once. Hinode marks every filtered table as
-// a data table, so an instance always exists by the time a button can be clicked.
+// Picking a category calls simple-datatables' search(term, [filterCol], 'category-filter'), so it
+// composes with sorting, pagination and the free-text search: the named source 'category-filter'
+// is independent of the search input, so both narrow the result set at once. Clearing the filter
+// ('All') instead calls multiSearch([], 'category-filter') - see below for why. Hinode marks every
+// filtered table as a data table, so an instance always exists by the time a button can be clicked.
 document.querySelectorAll('[data-filter-table]').forEach(btn => {
     btn.addEventListener('click', function () {
         const tableId = this.getAttribute('data-filter-table')

--- a/assets/js/modules/simple-datatables/simple-datatables.load.js
+++ b/assets/js/modules/simple-datatables/simple-datatables.load.js
@@ -191,10 +191,10 @@ document.querySelectorAll('.data-table').forEach(tbl => {
 })
 
 // Category filter button group.
-// Uses simple-datatables search(term, columns, source) when a DataTable instance
-// is available, so sorting, pagination and free-text search all continue to work
-// alongside category filtering. Falls back to direct DOM row toggling when no
-// DataTable is active on the table (e.g. filter-only without sortable/paginate/searchable).
+// Filtering runs through simple-datatables' search(term, columns, source), so it composes with
+// sorting, pagination and the free-text search: the named source 'category-filter' is independent
+// of the search input, so both narrow the result set at once. Hinode marks every filtered table as
+// a data table, so an instance always exists by the time a button can be clicked.
 document.querySelectorAll('[data-filter-table]').forEach(btn => {
     btn.addEventListener('click', function () {
         const tableId = this.getAttribute('data-filter-table')
@@ -206,30 +206,11 @@ document.querySelectorAll('[data-filter-table]').forEach(btn => {
         })
 
         const instances = tableFilterInstances[tableId]
-        if (instances) {
-            // DataTable path — filter persists across sorts and pagination updates.
-            // The named source 'category-filter' is independent of the built-in
-            // search input so both narrow the result set simultaneously.
-            instances.forEach(({ dt, filterCol }) => {
-                dt.search(filterValue, [filterCol], 'category-filter')
-            })
-        } else {
-            // Fallback: direct DOM manipulation (no simple-datatables on this table)
-            document.querySelectorAll(`[data-filter-container="${tableId}"]`).forEach(container => {
-                const table = container.querySelector('table')
-                if (!table) return
-                const col = parseInt(table.getAttribute('data-filter-col') ?? '1')
-                table.querySelectorAll('tbody tr').forEach(row => {
-                    if (!filterValue) {
-                        row.style.display = ''
-                        return
-                    }
-                    const cell = row.cells[col]
-                    const text = cell ? cell.textContent.trim().toLowerCase() : ''
-                    row.style.display = text.includes(filterValue) ? '' : 'none'
-                })
-            })
-        }
+        if (!instances) return
+
+        instances.forEach(({ dt, filterCol }) => {
+            dt.search(filterValue, [filterCol], 'category-filter')
+        })
     })
 })
 


### PR DESCRIPTION
Companion to gethinode/hinode's category-filter fix.

Hinode now marks every filtered table as a **data table**, so a DataTable instance always exists by the time a filter button can be clicked. Two consequences here.

## The DOM fallback is deleted

The click handler had a fallback branch that toggled `display` on each `tbody tr` directly when no DataTable existed. It is now unreachable — and it was the branch carrying a bug: it read `row.cells[col]` across every `tbody tr`, but a *wrapped* table renders two rows per record and the second holds a single `<td colspan>`. With the default `filter-col = 1`, `cells[1]` was `undefined` on that row, its text read as empty, and the description row was hidden the moment any filter became active — the record kept its data row but lost its description.

Filtering now always runs through simple-datatables' row model, so it composes correctly with sorting, pagination and the free-text search.

## Clearing the filter no longer wipes a typed search

`search(t, e, s = "search")` ignores its `source` argument on the empty-term path — it unconditionally resets `_searchQueries`. So clicking **All** (whose `data-filter-value` is `""`) cleared *every* query source, including the user's typed search term: the input still showed the text while the model had forgotten it.

The empty-term case now uses `multiSearch([], 'category-filter')`, which drops only the queries whose `source` matches and re-concats the rest. This is what the library does for itself when its own search input is cleared.

Verified in a browser with a negative control on the same DataTable instance: the old call left `_searchQueries = []`, the new one leaves `[search:alpha]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)