### PR TITLE
fix(datatables): keep the per-page control in sync with perPage

### DIFF
--- a/assets/js/modules/simple-datatables/simple-datatables.load.js
+++ b/assets/js/modules/simple-datatables/simple-datatables.load.js
@@ -144,12 +144,29 @@ document.querySelectorAll('.data-table').forEach(tbl => {
         perPageSelect = [5, 10, 20, 50, ["{{ T "tablePerPageSelectAll" }}", -1]];
     }
 
+    const perPage = parseInt(tbl.getAttribute('data-table-paging-option-perPage')) || 10;
+
+    // Keep the per-page control honest. When `perPage` is not one of the offered
+    // options the select falls back to rendering its first entry while the table
+    // pages at the requested size, so the control and the behaviour disagree with
+    // nothing to signal it — the reader sees "5" above a page of 25 rows.
+    // Inserting the value keeps the author's intent and makes the control show it.
+    // Entries may be a bare number or a [label, value] pair (the "All" entry), so
+    // compare against the value in either shape.
+    const perPageValue = entry => (Array.isArray(entry) ? entry[1] : entry);
+    if (!perPageSelect.some(entry => perPageValue(entry) === perPage)) {
+        const numeric = perPageSelect.filter(entry => perPageValue(entry) > 0);
+        const position = numeric.findIndex(entry => perPageValue(entry) > perPage);
+        perPageSelect = perPageSelect.slice();
+        perPageSelect.splice(position === -1 ? numeric.length : position, 0, perPage);
+    }
+
     const options = {
         ...tableOptions,
         sortable: (tbl.getAttribute('data-table-sortable') === 'true'),
         paging: (tbl.getAttribute('data-table-paging') === 'true'),
         searchable: (tbl.getAttribute('data-table-searchable') === 'true'),
-        perPage: parseInt(tbl.getAttribute('data-table-paging-option-perPage')) || 10,
+        perPage: perPage,
         perPageSelect: perPageSelect
     }
 


### PR DESCRIPTION
## The defect

`perPage` was passed straight to simple-datatables without being checked against `perPageSelect`. When the value is not one of the offered options, the select falls back to rendering its **first** entry while the table pages at the requested size — so the control and the behaviour disagree, and nothing signals it.

The reader sees "5" above a page of 25 rows. The only way to notice is to count them.

Measured on a real site with `perPage: 25` against the default options:

```text
data-table-paging-option-perPage = "25"
select.value                     = "5"        <- first option, not 25
visible tbody rows               = 25
select options                   = 5, 10, 20, 50, All
```

## The fix

Insert the value into the option list. That honours the author's intent and makes the control show what is actually happening:

```text
before   select "5",  25 rows, options 5/10/20/50/All
after    select "25", 25 rows, options 5/10/20/25/50/All
```

Of the three available outcomes — inject, warn and fall back, or render a mismatched value — the last is the worst, because it is silent. Injecting is closest to intent, since `perPage` is an explicit request.

## Details

The value lands in sorted position among the numeric entries, so **"All" stays last**. Entries may be a bare number or a `[label, value]` pair (that is how "All" carries `-1`), so the comparison reads the value in either shape and the sort ignores non-positive values.

A value already present is untouched: `perPage: 10` still yields `5/10/20/50/All` with the select on 10 and no injection.

## Related

A build-time counterpart shipped in [mod-blocks#185](https://github.com/gethinode/mod-blocks/pull/185), which warns at Hugo time when a `list` block's `pagination` is not a selectable size. That catches the common authoring path early but cannot cover callers reaching this module directly, or a custom `perPageSelect` — hence this runtime fix as well.

## Checks

`pnpm test` passes. Both cases exercised in a browser on a real 106-row table.