### PR TITLE
feat(wrap): fold a record into column groups

### DIFF
--- a/assets/js/modules/simple-datatables/simple-datatables.load.js
+++ b/assets/js/modules/simple-datatables/simple-datatables.load.js
@@ -40,7 +40,35 @@ const dataTableBreakpoints = { xs: 0, sm: 576, md: 768, lg: 992, xl: 1200, xxl: 
 // small devices. This rewrites the virtual DOM only - never the row model - so sorting, searching
 // and paging keep operating on the unmodified data, and the pager keeps counting records rather
 // than rendered rows.
-const wrapLastColumn = (table) => {
+// Splits `total` columns into the group sizes the author asked for, or returns null when the
+// request does not describe this table. A group list must be positive integers summing to the
+// column count: anything else would silently drop or duplicate a column, so it is refused here
+// and the caller falls back to the default split.
+const parseColumnGroups = (spec, total) => {
+    if (!spec) {
+        return null
+    }
+    const groups = String(spec).split(",").map(part => Number.parseInt(part.trim(), 10))
+    if (groups.some(n => !Number.isInteger(n) || n < 1)) {
+        return null
+    }
+    if (groups.reduce((sum, n) => sum + n, 0) !== total) {
+        return null
+    }
+    return groups
+}
+
+// Moves trailing columns of every record onto rows of their own, so wide tables stay readable on
+// small devices. This rewrites the virtual DOM only - never the row model - so sorting, searching
+// and paging keep operating on the unmodified data, and the pager keeps counting records rather
+// than rendered rows.
+//
+// `groups` gives the column count per rendered row: [n-1, 1] is the original behaviour, where the
+// last column drops to a row of its own. Only the first group keeps one cell per column, so it
+// alone drives the column grid; every later group collapses into a single spanning cell. Letting a
+// later group keep separate cells would make the browser reconcile several conflicting column
+// counts within one table, and the widths stop meaning anything.
+const wrapColumnGroups = (table, groups) => {
     const thead = table.childNodes[0]
     const tbody = table.childNodes[1]
     const headerRow = thead?.childNodes[0]
@@ -48,11 +76,15 @@ const wrapLastColumn = (table) => {
         return table
     }
 
-    // Hides the heading of the wrapped column, rather than removing it. The library measures column
-    // widths by walking the rendered `<th>` list in lockstep with its row model, so the header must
-    // keep all of its cells. This mirrors Hinode's plain-table wrap, which hides the heading too.
-    const lastHeader = headerRow.childNodes.length - 1
-    headerRow.childNodes = headerRow.childNodes.map((th, index) => index !== lastHeader
+    const total = headerRow.childNodes.length
+    const split = groups ?? [total - 1, 1]
+    const lead = split[0]
+
+    // Hides the headings of every wrapped column, rather than removing them. The library measures
+    // column widths by walking the rendered `<th>` list in lockstep with its row model, so the
+    // header must keep all of its cells. This mirrors Hinode's plain-table wrap, which hides the
+    // heading too.
+    headerRow.childNodes = headerRow.childNodes.map((th, index) => index < lead
         ? th
         : {
             ...th,
@@ -62,10 +94,14 @@ const wrapLastColumn = (table) => {
             }
         })
 
-    // Marks the table for the wrap-specific striping rules in Hinode's SCSS.
+    // Marks the table for the wrap-specific striping rules in Hinode's SCSS. The row count per
+    // record keys which rule applies, since the stripe repeats every two records. Only past the
+    // default two, which the plain `table-wrap` selector already covers - matching what the
+    // server-side wrap in render-table.html emits, so the two paths style identically.
+    const countClass = split.length > 2 ? ` table-wrap-${split.length}` : ""
     table.attributes = {
         ...table.attributes,
-        class: `${table.attributes?.class ?? ""} table-wrap`.trim()
+        class: `${table.attributes?.class ?? ""} table-wrap${countClass}`.trim()
     }
 
     tbody.childNodes = tbody.childNodes.flatMap(row => {
@@ -73,31 +109,76 @@ const wrapLastColumn = (table) => {
         if (!cells || cells.length < 2) {
             return [row]
         }
-        const span = cells.length - 1
-        const last = cells[span]
 
-        return [
-            {
-                ...row,
-                childNodes: cells.slice(0, span).map(cell => ({
-                    ...cell,
-                    attributes: {
-                        ...cell.attributes,
-                        class: `${cell.attributes?.class ?? ""} table-border-bottom-wrap`.trim()
-                    }
-                }))
-            },
-            {
+        const rows = []
+        let offset = 0
+        split.forEach((size, groupIndex) => {
+            const group = cells.slice(offset, offset + size)
+            offset += size
+
+            if (groupIndex === 0) {
+                // The lead row keeps one cell per column and adds no colspan of its own. Its cell
+                // count is what the table's column grid is built from - the folded headings are
+                // display:none and contribute no column - so a folded row must span exactly this
+                // many columns. Widening a lead cell here instead would declare more columns than
+                // the grid holds, and the folded rows would stop short of the table's edge, leaving
+                // their stripe and bottom border cut off part way across.
+                rows.push({
+                    ...row,
+                    childNodes: group.map(cell => ({
+                        ...cell,
+                        attributes: {
+                            ...cell.attributes,
+                            class: `${cell.attributes?.class ?? ""} table-border-bottom-wrap`.trim()
+                        }
+                    }))
+                })
+                return
+            }
+
+            // A folded group becomes one spanning cell holding that group's values side by side.
+            // The heading is hidden above, so the values carry no label - fine for self-describing
+            // content such as badges, and the reason the group list is the author's to choose.
+            const last = groupIndex === split.length - 1
+            rows.push({
                 nodeName: "TR",
                 // Carries the source row's attributes, so `data-index` survives on the synthesized
                 // row and the library's row-selection handler keeps reporting the right record.
                 attributes: { ...row.attributes },
                 childNodes: [{
-                    ...last,
-                    attributes: { ...last.attributes, colspan: String(span) }
+                    nodeName: "TD",
+                    attributes: {
+                        colspan: String(lead),
+                        class: `table-wrap-group-cell${last ? "" : " table-border-bottom-wrap"}`
+                    },
+                    // The layout goes on an inner element, never on the cell. A `display` of grid or
+                    // flex takes a `td` out of the table formatting context, and `colspan` stops
+                    // applying with it - the cell then covers one column instead of the row, so its
+                    // stripe and border stop part way across the table.
+                    childNodes: [{
+                        nodeName: "DIV",
+                        attributes: { class: "table-wrap-group" },
+                        // Each source cell keeps its own wrapper rather than having its children
+                        // merged into the group. Merging concatenates plain-text cells into one run
+                        // ("DatabaselaunchShipped"), and no styling on the group separates them:
+                        // adjacent text nodes collapse into a single anonymous box. A span per
+                        // column gives one grid item per value whatever the cell holds.
+                        // The source cell's own classes ride along: the markdown render hook puts
+                        // the column's alignment there (`text-center`, `text-end`), and folding the
+                        // column must not silently left-align a table the author aligned otherwise.
+                        childNodes: group.map(cell => ({
+                            nodeName: "SPAN",
+                            attributes: {
+                                class: `table-wrap-value ${cell.attributes?.class ?? ""}`.trim()
+                            },
+                            childNodes: cell.childNodes ?? []
+                        }))
+                    }]
                 }]
-            }
-        ]
+            })
+        })
+
+        return rows
     })
 
     return table
@@ -174,10 +255,12 @@ document.querySelectorAll('.data-table').forEach(tbl => {
     // `xs` the max-width evaluates below zero, so the query never matches and wrapping is off -
     // matching Hinode, which does not emit the attribute at `xs` either.
     let media = null
+    let wrapCols = null
     if (tbl.getAttribute('data-table-wrap') === 'true') {
         const name = tbl.getAttribute('data-table-wrap-breakpoint') || 'md'
         const width = dataTableBreakpoints[name] ?? dataTableBreakpoints.md
         media = window.matchMedia(`(max-width: ${width - 0.02}px)`)
+        wrapCols = tbl.getAttribute('data-table-wrap-cols')
     }
 
     options.tableRender = (_data, table, type) => {
@@ -187,7 +270,10 @@ document.querySelectorAll('.data-table').forEach(tbl => {
         if (type !== 'main' || !media?.matches) {
             return rendered
         }
-        return wrapLastColumn(rendered)
+        // Parsed per render rather than once: the column count comes from the rendered header, and
+        // an invalid group list falls back to the default split rather than failing the table.
+        const headerCells = rendered.childNodes[0]?.childNodes[0]?.childNodes?.length ?? 0
+        return wrapColumnGroups(rendered, parseColumnGroups(wrapCols, headerCells))
     }
 
     const dt = new window.simpleDatatables.DataTable(tbl, options)


### PR DESCRIPTION
## Summary

Generalises the wrap from "move the last column to its own row" to "fold a record into column groups", so a wide table can stack as a card on a phone instead of scrolling sideways.

Driven by `data-table-wrap-cols`, a comma-separated column count per rendered row. `2,4,1` on a seven-column table keeps `#` and Name on the lead row, folds four badges onto a row of their own, and gives the description the last. The default stays `[n-1, 1]`.

Pairs with gethinode/hinode#TBD, which adds the `wrap-cols` argument and the matching styling.

## Why not just widen the existing wrap

Folding one column was not enough. On a 390px viewport a seven-column catalog table still measured 487px against a 358px container after the last column was folded — the remaining columns are each narrow, but there are too many. Folding the badge columns as a group removes the horizontal scroll entirely.

## Design notes

**Only the first group keeps one cell per column**, and it alone drives the column grid; later groups collapse into a single spanning cell. Letting a later group keep separate cells makes the browser reconcile several conflicting column counts within one table, and the widths stop meaning anything.

**`colspan` counts the lead group, not every column.** The folded headings are `display: none` and contribute no column, so spanning the full count reaches past the grid and the folded row's stripe and bottom border stop part way across the table.

**The layout wrapper is inside the cell, never on it.** A `display` of grid or flex on a `td` takes it out of the table formatting context and `colspan` stops applying with it — same visible symptom as above, found the hard way.

**Each folded cell keeps its own span.** Merging their children concatenates plain-text cells into one run (`DatabaselaunchShipped`) and no styling on the group separates them: adjacent text nodes collapse into a single anonymous box. The span also carries the source cell's classes, so the markdown column alignment the render hook records (`text-center`, `text-end`) survives folding.

**An invalid group list is refused**, falling back to the default split. Every entry must be a positive integer and the total must match the column count, so a list left stale when a column is added folds on the default boundaries rather than silently dropping or duplicating a column.

This still rewrites the virtual DOM only, never the row model, so sorting, searching and paging keep operating on unmodified data and the pager keeps counting records rather than rendered rows.

## Testing

Driven in a browser against hinode's example site at 390px and 1440px, with fixtures for a three-group data table, the same split on a plain table, and a stale group list.

- **390px** — `table-wrap table-wrap-3`, `#`/Name headers visible and the rest hidden, three rows per record, folded rows spanning the table's full width, no horizontal overflow, chips laid out in equal columns on a single line.
- **1440px** — unwrapped, all seven headers, seven cells per row; sorting by Name still reorders correctly, confirming the row model was untouched.
- **Stale list** (`2,4` across seven columns) — falls back to `table-wrap` with two rows per record and a single folded value, identical to the pre-existing behaviour.
- **Regression** — the existing default two-row fixtures are unchanged and carry no row-count class.

`pnpm test` passes.
